### PR TITLE
Update tdi_pipeline_builder parameter string

### DIFF
--- a/docs/apps/lnw/dpdk/dpdk-linux-networking-ecmp.md
+++ b/docs/apps/lnw/dpdk/dpdk-linux-networking-ecmp.md
@@ -63,9 +63,9 @@ repository and follow the readme for procedure.
   p4c-dpdk --arch pna --target dpdk \
       --p4runtime-files $OUTPUT_DIR/p4Info.txt \
       --bf-rt-schema $OUTPUT_DIR/bf-rt.json \
-	  --context $OUTPUT_DIR/context.json \
-	  -o $OUTPUT_DIR/linux_networking.spec \
-	  linux_networking.p4
+      --context $OUTPUT_DIR/context.json \
+      -o $OUTPUT_DIR/linux_networking.spec \
+      linux_networking.p4
   ```
 
 - Modify sample lnw.conf file available in $IPDK_RECIPE/p4src/linux_networking/
@@ -220,7 +220,7 @@ Using one of the TAP ports for tunnel termination.
 ```bash
 sudo $P4CP_INSTALL/bin/ovs-vsctl add-port br-int vxlan1 -- \
     set interface vxlan1 type=vxlan options:local_ip=40.1.1.1 \
-	options:remote_ip=30.1.1.1 options:dst_port=4789
+    options:remote_ip=30.1.1.1 options:dst_port=4789
 ```
 
 Note:

--- a/docs/apps/lnw/dpdk/dpdk-linux-networking-ecmp.md
+++ b/docs/apps/lnw/dpdk/dpdk-linux-networking-ecmp.md
@@ -1,6 +1,6 @@
 <!--
 /*
- * Copyright 2022-2023 Intel Corporation.
+ * Copyright 2022-2024 Intel Corporation.
  *
  * SPDX-License-Identifier: Apache-2.0
  *
@@ -74,7 +74,7 @@ repository and follow the readme for procedure.
 - Generate binary file using the following tdi-pipeline builder command:
 
   ```bash
-  tdi_pipeline_builder --p4c_conf_file=lnw.conf --bf_pipeline_config_binary_file=lnw.pb.bin
+  tdi_pipeline_builder --p4c_conf_file=lnw.conf --tdi_pipeline_config_binary_file=lnw.pb.bin
   ```
 
 ## Steps to create the topology

--- a/docs/apps/lnw/dpdk/dpdk-linux-networking.md
+++ b/docs/apps/lnw/dpdk/dpdk-linux-networking.md
@@ -1,6 +1,6 @@
 <!--
 /*
- * Copyright 2022-2023 Intel Corporation.
+ * Copyright 2022-2024 Intel Corporation.
  *
  * SPDX-License-Identifier: Apache-2.0
  *
@@ -70,7 +70,7 @@ VxLAN.  Note the limitations below before setting up the topology.
 - Generate binary file using the following tdi-pipeline builder command:
 
   ```bash
-  tdi_pipeline_builder --p4c_conf_file=lnw.conf --bf_pipeline_config_binary_file=lnw.pb.bin
+  tdi_pipeline_builder --p4c_conf_file=lnw.conf --tdi_pipeline_config_binary_file=lnw.pb.bin
   ```
 
 ## Creating the topology

--- a/docs/clients/p4rt-ctl.rst
+++ b/docs/clients/p4rt-ctl.rst
@@ -1,5 +1,5 @@
 ..
-      Copyright 2021-2023 Intel Corporation
+      Copyright 2021-2024 Intel Corporation
       SPDX-License-Identifier: Apache-2.0
 
 ========
@@ -59,14 +59,14 @@ To generate pb.bin:
 .. code-block:: bash
 
    tdi_pipeline_builder --p4c_conf_file="<path-to-input-sample-file.conf>" \
-       --bf_pipeline_config_binary_file="<path-to-output-file.pb.bin>"
+       --tdi_pipeline_config_binary_file="<path-to-output-file.pb.bin>"
 
 For example,
 
 .. code-block:: bash
 
    tdi_pipeline_builder --p4c_conf_file=/home/mydir/sample.conf \
-       --bf_pipeline_config_binary_file=/home/mydir/sample.pb.bin
+       --tdi_pipeline_config_binary_file=/home/mydir/sample.pb.bin
 
 .. important::
 

--- a/docs/guides/es2k/running-infrap4d.md
+++ b/docs/guides/es2k/running-infrap4d.md
@@ -198,7 +198,7 @@ forwarding pipeline binary.
 ```bash
 $P4CP_INSTALL/bin/tdi_pipeline_builder \
     --p4c_conf_file=/usr/share/stratum/es2k/es2k_skip_p4.conf \
-    --bf_pipeline_config_binary_file=$OUTPUT_DIR/l3-fwd_sem.pb.bin
+    --tdi_pipeline_config_binary_file=$OUTPUT_DIR/l3-fwd_sem.pb.bin
 ```
 
 ## 5. Start Infrap4d

--- a/docs/guides/setup/dpdk-setup-guide.md
+++ b/docs/guides/setup/dpdk-setup-guide.md
@@ -214,7 +214,7 @@ and context.json).
 ```bash
 $P4CP_INSTALL/bin/tdi_pipeline_builder \
     --p4c_conf_file=$OUTPUT_DIR/simple_l3.conf \
-    --bf_pipeline_config_binary_file=$OUTPUT_DIR/simple_l3.pb.bin
+    --tdi_pipeline_config_binary_file=$OUTPUT_DIR/simple_l3.pb.bin
 ```
 
 #### Set forwarding pipeline

--- a/docs/guides/setup/es2k-setup-guide.md
+++ b/docs/guides/setup/es2k-setup-guide.md
@@ -241,7 +241,7 @@ touch tofino.bin
 ```bash
 $P4CP_INSTALL/bin/tdi_pipeline_builder \
     --p4c_conf_file=$OUTPUT_DIR/simple_l3_l4_pna.conf \
-    --bf_pipeline_config_binary_file=$OUTPUT_DIR/simple_l3_l4_pna.pb.bin
+    --tdi_pipeline_config_binary_file=$OUTPUT_DIR/simple_l3_l4_pna.pb.bin
 ```
 
 ### Set forwarding pipeline

--- a/docs/guides/setup/tofino-setup-guide.md
+++ b/docs/guides/setup/tofino-setup-guide.md
@@ -165,5 +165,5 @@ cd $SDE_INSTALL
 LD_LIBRARY_PATH=$P4CP_RECIPE/install/lib/:$SDE_INSTALL/lib \
     $P4CP_RECIPE/install/bin/tdi_pipeline_builder \
     -p4c_conf_file=$SDE_INSTALL/share/p4/targets/tofino/tna_exact_match.conf \
-    -bf_pipeline_config_binary_file=$P4CP_RECIPE/tna_exact_match.pb.bin
+    -tdi_pipeline_config_binary_file=$P4CP_RECIPE/tna_exact_match.pb.bin
 ```


### PR DESCRIPTION
This CL updates all references to the parameter passed to the `tdi_pipeline_builder` program from `bf_pipeline_config_binary_file` to `tdi_pipeline_config_binary_file`. This change is part of the effort to update names removing the `bf_` legacy from codebase and naming convention