### PR TITLE
Remove LNWv2 documentation references

### DIFF
--- a/docs/apps/lnw/es2k/es2k-lnw-overlay-ipv6.md
+++ b/docs/apps/lnw/es2k/es2k-lnw-overlay-ipv6.md
@@ -31,17 +31,19 @@ for more details on this feature.
 
 Prerequisites:
 
-- Download `hw-p4-programs` TAR file specific to the build and extract it to get `fxp-net_linux-networking-v2` p4 artifacts. Go through `Limitations` specified in `README` and bring up the setup accordingly.
-- Follow steps mentioned in [Deploying P4 Programs for E2100](/guides/es2k/deploying-p4-programs) for bringing up IPU with a custom P4 package.
+- For Linux Networking v3
+  - Download `hw-p4-programs` TAR file compliant with the CI build image and extract it to get `fxp-net_linux-networking-v3` P4 artifacts. Check readme for bring up guide, and be sure to check limitation for known issues.
+
+  - Follow steps mentioned in [Deploying P4 Programs for E2100](/guides/es2k/deploying-p4-programs) for bringing up IPU with a custom P4 package.
 Modify `load_custom_pkg.sh` with following parameters for linux_networking package:
 
-```text
-    sed -i 's/sem_num_pages = 1;/sem_num_pages = 25;/g' $CP_INIT_CFG
-    sed -i 's/lem_num_pages = 1;/lem_num_pages = 10;/g' $CP_INIT_CFG
-    sed -i 's/acc_apf = 4;/acc_apf = 8;/g' $CP_INIT_CFG
-```
+     ```text
+        sed -i 's/sem_num_pages = 1;/sem_num_pages = 28;/g' $CP_INIT_CFG
+        sed -i 's/lem_num_pages = 1;/lem_num_pages = 10;/g' $CP_INIT_CFG
+        sed -i 's/allow_change_mac_address = false;/allow_change_mac_address = true;/g' $CP_INIT_CFG
+        sed -i 's/acc_apf = 4;/acc_apf = 16;/g' $CP_INIT_CFG
 
-- Download `IPU_Documentation` TAR file specific to the build and refer to `Getting Started Guide` on how to install compatible `IDPF driver` on host. Once an IDPF driver is installed, bring up SRIOV VF by modifying the `sriov_numvfs` file present under one of the IDPF network devices. Example as below
+- Download `IPU_Documentation` TAR file compliant with the CI build image and refer to `Getting Started Guide` on how to install compatible `IDPF driver` on host. Once an IDPF driver is installed, bring up SRIOV VF by modifying the `sriov_numvfs` file present under one of the IDPF network devices. Example as below
 
   ```bash
   echo 1 > /sys/class/net/ens802f0/device/sriov_numvfs
@@ -68,7 +70,8 @@ System under test will have above topology running the networking recipe. Link P
 
 ## Creating the topology
 
-Follow steps mentioned in [Running Infrap4d on Intel E2100](/guides/es2k/running-infrap4d.md) for starting `infrap4d` process and creating protobuf binary for `fxp-net_linux-networking-v2` p4 program.
+- For Linux Networking v3
+  Follow steps mentioned in [Running Infrap4d on Intel E2100](/guides/es2k/running-infrap4d.md) for starting `infrap4d` process and creating protobuf binary for `fxp-net_linux-networking-v3` P4 program.
 
 ### Port mapping
 
@@ -100,12 +103,14 @@ These VSI values can be checked with `/usr/bin/cli_client -q -c` command on IMC.
 Once the application is started, set the forwarding pipeline config using
 P4Runtime Client `p4rt-ctl` set-pipe command
 
-```bash
-$P4CP_INSTALL/bin/p4rt-ctl set-pipe br0 $OUTPUT_DIR/fxp-net_linux-networking-v2.pb.bin \
-    $OUTPUT_DIR/p4info.txt
-```
+- For Linux Networking v3
 
-Note: Assumes that `fxp-net_linux-networking-v2.pb.bin`, `p4info.txt` and other P4 artifacts, are created by following the steps in the previous section.
+  ```bash
+     $P4CP_INSTALL/bin/p4rt-ctl set-pipe br0 $OUTPUT_DIR/fxp-net_linux-networking-v3.pb.bin \
+     $OUTPUT_DIR/p4info.txt
+  ```
+
+Note: Assumes that `fxp-net_linux-networking-v3.pb.bin`, `p4info.txt` and other P4 artifacts, are created by following the steps in the previous section.
 
 ### Configure VSI Group and add a netdev
 

--- a/docs/apps/lnw/es2k/es2k-lnw-overlay-ipv6.md
+++ b/docs/apps/lnw/es2k/es2k-lnw-overlay-ipv6.md
@@ -37,11 +37,12 @@ Prerequisites:
   - Follow steps mentioned in [Deploying P4 Programs for E2100](/guides/es2k/deploying-p4-programs) for bringing up IPU with a custom P4 package.
 Modify `load_custom_pkg.sh` with following parameters for linux_networking package:
 
-     ```text
-        sed -i 's/sem_num_pages = 1;/sem_num_pages = 28;/g' $CP_INIT_CFG
-        sed -i 's/lem_num_pages = 1;/lem_num_pages = 10;/g' $CP_INIT_CFG
-        sed -i 's/allow_change_mac_address = false;/allow_change_mac_address = true;/g' $CP_INIT_CFG
-        sed -i 's/acc_apf = 4;/acc_apf = 16;/g' $CP_INIT_CFG
+     ```bash
+    sed -i 's/sem_num_pages = 1;/sem_num_pages = 28;/g' $CP_INIT_CFG
+    sed -i 's/lem_num_pages = 6;/lem_num_pages = 10;/g' $CP_INIT_CFG
+    sed -i 's/allow_change_mac_address = false;/allow_change_mac_address = true;/g' $CP_INIT_CFG
+    sed -i 's/acc_apf = 4;/acc_apf = 16;/g' $CP_INIT_CFG
+    ```
 
 - Download `IPU_Documentation` TAR file compliant with the CI build image and refer to `Getting Started Guide` on how to install compatible `IDPF driver` on host. Once an IDPF driver is installed, bring up SRIOV VF by modifying the `sriov_numvfs` file present under one of the IDPF network devices. Example as below
 
@@ -105,10 +106,9 @@ P4Runtime Client `p4rt-ctl` set-pipe command
 
 - For Linux Networking v3
 
-  ```bash
-     $P4CP_INSTALL/bin/p4rt-ctl set-pipe br0 $OUTPUT_DIR/fxp-net_linux-networking-v3.pb.bin \
-     $OUTPUT_DIR/p4info.txt
-  ```
+    ```bash
+    $P4CP_INSTALL/bin/p4rt-ctl set-pipe br0 $OUTPUT_DIR/fxp-net_linux-networking-v3.pb.bin $OUTPUT_DIR/p4info.txt
+    ```
 
 Note: Assumes that `fxp-net_linux-networking-v3.pb.bin`, `p4info.txt` and other P4 artifacts, are created by following the steps in the previous section.
 
@@ -300,36 +300,35 @@ Example:
 For TCAM entry configure LPM LUT table
 
 ```bash
- p4rt-ctl add-entry br0 linux_networking_control.ipv6_lpm_root_lut \
-     "user_meta.cmeta.bit32_zeros=0/255.255.255.255,priority=65535,action=linux_networking_control.ipv6_lpm_root_lut_action(0)"
+p4rt-ctl add-entry br0 linux_networking_control.ipv6_lpm_root_lut "user_meta.cmeta.bit16_zeros=0/65535,priority=2048,action=linux_networking_control.ipv6_lpm_root_lut_action(0)"
 ```
 
 Create a dummy LAG bypass table for all 8 hash indexes
 
 ```bash
- p4rt-ctl add-entry br0  linux_networking_control.tx_lag_table \
-     "user_meta.cmeta.lag_group_id=0,hash=0,action=linux_networking_control.bypass"
+p4rt-ctl add-entry br0  linux_networking_control.tx_lag_table \
+    "user_meta.cmeta.lag_group_id=0,hash=0,action=linux_networking_control.bypass"
 
- p4rt-ctl add-entry br0  linux_networking_control.tx_lag_table \
-     "user_meta.cmeta.lag_group_id=0,hash=1,action=linux_networking_control.bypass"
+p4rt-ctl add-entry br0  linux_networking_control.tx_lag_table \
+    "user_meta.cmeta.lag_group_id=0,hash=1,action=linux_networking_control.bypass"
 
- p4rt-ctl add-entry br0  linux_networking_control.tx_lag_table \
-     "user_meta.cmeta.lag_group_id=0,hash=2,action=linux_networking_control.bypass"
+p4rt-ctl add-entry br0  linux_networking_control.tx_lag_table \
+    "user_meta.cmeta.lag_group_id=0,hash=2,action=linux_networking_control.bypass"
 
- p4rt-ctl add-entry br0  linux_networking_control.tx_lag_table \
-     "user_meta.cmeta.lag_group_id=0,hash=3,action=linux_networking_control.bypass"
+p4rt-ctl add-entry br0  linux_networking_control.tx_lag_table \
+    "user_meta.cmeta.lag_group_id=0,hash=3,action=linux_networking_control.bypass"
 
- p4rt-ctl add-entry br0  linux_networking_control.tx_lag_table \
-     "user_meta.cmeta.lag_group_id=0,hash=4,action=linux_networking_control.bypass"
+p4rt-ctl add-entry br0  linux_networking_control.tx_lag_table \
+    "user_meta.cmeta.lag_group_id=0,hash=4,action=linux_networking_control.bypass"
 
- p4rt-ctl add-entry br0  linux_networking_control.tx_lag_table \
-     "user_meta.cmeta.lag_group_id=0,hash=5,action=linux_networking_control.bypass"
+p4rt-ctl add-entry br0  linux_networking_control.tx_lag_table \
+    "user_meta.cmeta.lag_group_id=0,hash=5,action=linux_networking_control.bypass"
 
- p4rt-ctl add-entry br0  linux_networking_control.tx_lag_table \
-     "user_meta.cmeta.lag_group_id=0,hash=6,action=linux_networking_control.bypass"
+p4rt-ctl add-entry br0  linux_networking_control.tx_lag_table \
+    "user_meta.cmeta.lag_group_id=0,hash=6,action=linux_networking_control.bypass"
 
- p4rt-ctl add-entry br0  linux_networking_control.tx_lag_table \
-     "user_meta.cmeta.lag_group_id=0,hash=7,action=linux_networking_control.bypass"
+p4rt-ctl add-entry br0  linux_networking_control.tx_lag_table \
+    "user_meta.cmeta.lag_group_id=0,hash=7,action=linux_networking_control.bypass"
 ```
 
 ### Create integration bridge and add ports to the bridge

--- a/docs/apps/lnw/es2k/es2k-lnw-overlay-vms.md
+++ b/docs/apps/lnw/es2k/es2k-lnw-overlay-vms.md
@@ -38,7 +38,7 @@ Modify `load_custom_pkg.sh` with following parameters for linux_networking packa
 
      ```text
         sed -i 's/sem_num_pages = 1;/sem_num_pages = 28;/g' $CP_INIT_CFG
-        sed -i 's/lem_num_pages = 1;/lem_num_pages = 10;/g' $CP_INIT_CFG
+        sed -i 's/lem_num_pages = 6;/lem_num_pages = 10;/g' $CP_INIT_CFG
         sed -i 's/mod_num_pages = 1;/mod_num_pages = 2;/g' $CP_INIT_CFG
         sed -i 's/acc_apf = 4;/acc_apf = 16;/g' $CP_INIT_CFG
      ```

--- a/docs/apps/lnw/es2k/es2k-lnw-overlay-vms.md
+++ b/docs/apps/lnw/es2k/es2k-lnw-overlay-vms.md
@@ -31,17 +31,6 @@ for more details on this feature.
 
 Prerequisites:
 
-- For Linux Networking v2
-  - Download `hw-p4-programs` TAR file compliant with the CI build image and extract it to get `fxp-net_linux-networking-v2` P4 artifacts. Check `README` for bringup guide, and be sure to check `Limitations` for known issues.
-  - Follow steps mentioned in [Deploying P4 Programs for E2100](/guides/es2k/deploying-p4-programs) for bringing up IPU with a custom P4 package.
-Modify `load_custom_pkg.sh` with following parameters for linux_networking package:
-
-    ```text
-       sed -i 's/sem_num_pages = 1;/sem_num_pages = 25;/g' $CP_INIT_CFG
-       sed -i 's/lem_num_pages = 1;/lem_num_pages = 10;/g' $CP_INIT_CFG
-       sed -i 's/acc_apf = 4;/acc_apf = 16;/g' $CP_INIT_CFG
-    ```
-
 - For Linux Networking v3
   - Download `hw-p4-programs` TAR file compliant with the CI build image and extract it to get `fxp-net_linux-networking-v3` P4 artifacts. Check `README` for bringup guide, and be sure to check `Limitations` for known issues.
   - Follow steps mentioned in [Deploying P4 Programs for E2100](/guides/es2k/deploying-p4-programs) for bringing up IPU with a custom P4 package.
@@ -78,9 +67,6 @@ Notes about topology:
 System under test will have above topology running the networking recipe. Link Partner can have the networking recipe or legacy OvS or kernel VxLAN. Refer to the limitation section in [Linux Networking for E2100](es2k-linux-networking.md) before setting up the topology.
 
 ## Creating the topology
-
-- For Linux Networking v2
-  Follow steps mentioned in [Running Infrap4d on Intel E2100](/guides/es2k/running-infrap4d.md) for starting `infrap4d` process and creating protobuf binary for `fxp-net_linux-networking-v2` P4 program.
 
 - For Linux Networking v3
   Follow steps mentioned in [Running Infrap4d on Intel E2100](/guides/es2k/running-infrap4d.md) for starting `infrap4d` process and creating protobuf binary for `fxp-net_linux-networking-v3` P4 program.
@@ -121,13 +107,6 @@ These VSI values can be checked with `/usr/bin/cli_client -q -c` command on IMC.
 
 Once the application is started, set the forwarding pipeline config using
 P4Runtime Client `p4rt-ctl` set-pipe command
-
-- For Linux Networking v2
-
-  ```bash
-     $P4CP_INSTALL/bin/p4rt-ctl set-pipe br0 $OUTPUT_DIR/fxp-net_linux-networking-v2.pb.bin \
-     $OUTPUT_DIR/p4info.txt
-  ```
 
 - For Linux Networking v3
 
@@ -241,14 +220,6 @@ Example:
 - Corresponding port representor VSI value 9
 - If a VSI is used as an action, add an offset of 16 to the VSI value
 
-- For Linux Networking v2
-
-  ```bash
-     # Create a source port for an overlay VF (VSI-27). Source port value should be VSI ID + 16.
-      p4rt-ctl add-entry br0 linux_networking_control.tx_source_port_v4 \
-      "vmeta.common.vsi=27,zero_padding=0,action=linux_networking_control.set_source_port(43)"
-   ```
-
 - For Linux Networking v3
 
   ```bash
@@ -317,14 +288,6 @@ Example:
 - Corresponding port representor VSI value 18
 - If a VSI is used as an action, add an offset of 16 to the VSI value
 
-- For Linux Networking v2
-
-  ```bash
-     # Create a source port for an APF netdev (VSI-24). Source port value should be VSI ID + 16.
-      p4rt-ctl add-entry br0 linux_networking_control.tx_source_port_v4 \
-      "vmeta.common.vsi=24,zero_padding=0,action=linux_networking_control.set_source_port(40)"
-   ```
-
 - For Linux Networking v3
 
   ```bash
@@ -355,13 +318,6 @@ Example:
 
 For TCAM entry configure LPM LUT table
 
-- For Linux Networking v2
-
-```bash
- p4rt-ctl add-entry br0 linux_networking_control.ipv4_lpm_root_lut \
-     "user_meta.cmeta.bit32_zeros=4/255.255.255.255,priority=65535,action=linux_networking_control.ipv4_lpm_root_lut_action(0)"
-```
-
 - For Linux Networking v3
 
 ```bash
@@ -370,34 +326,6 @@ For TCAM entry configure LPM LUT table
 ```
 
 Create a dummy LAG bypass table for all 8 hash indexes
-
-- For Linux Networking v2
-
-  ```bash
-     p4rt-ctl add-entry br0  linux_networking_control.tx_lag_table \
-      "user_meta.cmeta.lag_group_id=0,hash=0,action=linux_networking_control.bypass"
-
-     p4rt-ctl add-entry br0  linux_networking_control.tx_lag_table \
-      "user_meta.cmeta.lag_group_id=0,hash=1,action=linux_networking_control.bypass"
-
-     p4rt-ctl add-entry br0  linux_networking_control.tx_lag_table \
-      "user_meta.cmeta.lag_group_id=0,hash=2,action=linux_networking_control.bypass"
-
-     p4rt-ctl add-entry br0  linux_networking_control.tx_lag_table \
-      "user_meta.cmeta.lag_group_id=0,hash=3,action=linux_networking_control.bypass"
-
-     p4rt-ctl add-entry br0  linux_networking_control.tx_lag_table \
-      "user_meta.cmeta.lag_group_id=0,hash=4,action=linux_networking_control.bypass"
-
-     p4rt-ctl add-entry br0  linux_networking_control.tx_lag_table \
-      "user_meta.cmeta.lag_group_id=0,hash=5,action=linux_networking_control.bypass"
-
-     p4rt-ctl add-entry br0  linux_networking_control.tx_lag_table \
-      "user_meta.cmeta.lag_group_id=0,hash=6,action=linux_networking_control.bypass"
-
-     p4rt-ctl add-entry br0  linux_networking_control.tx_lag_table \
-      "user_meta.cmeta.lag_group_id=0,hash=7,action=linux_networking_control.bypass"
-   ```
 
 - For Linux Networking v3
 

--- a/docs/apps/lnw/es2k/es2k-lnw-underlay-ecmp.md
+++ b/docs/apps/lnw/es2k/es2k-lnw-underlay-ecmp.md
@@ -31,17 +31,6 @@ for more details on this feature.
 
 Prerequisites:
 
-- For Linux Networking v2
-  - Download `hw-p4-programs` TAR file compliant with the CI build image and extract it to get `fxp-net_linux-networking-v2` P4 artifacts. Check `README` for bringup guide, and be sure to check `Limitations` for known issues.
-  - Follow steps mentioned in [Deploying P4 Programs for E2100](/guides/es2k/deploying-p4-programs) for bringing up IPU with a custom P4 package.
-Modify `load_custom_pkg.sh` with following parameters for linux_networking package:
-
-    ```text
-       sed -i 's/sem_num_pages = 1;/sem_num_pages = 25;/g' $CP_INIT_CFG
-       sed -i 's/lem_num_pages = 1;/lem_num_pages = 10;/g' $CP_INIT_CFG
-       sed -i 's/acc_apf = 4;/acc_apf = 16;/g' $CP_INIT_CFG
-    ```
-
 - For Linux Networking v3
   - Download `hw-p4-programs` TAR file compliant with the CI build image and extract it to get `fxp-net_linux-networking-v3` P4 artifacts. Check `README` for bringup guide, and be sure to check `Limitations` for known issues.
 
@@ -82,9 +71,6 @@ System under test will have above topology running the networking recipe. Link P
 
 ## Creating the topology
 
-- For Linux Networking v2
-  Follow steps mentioned in [Running Infrap4d on Intel E2100](/guides/es2k/running-infrap4d.md) for starting `infrap4d` process and creating protobuf binary for `fxp-net_linux-networking-v2` P4 program.
-
 - For Linux Networking v3
   Follow steps mentioned in [Running Infrap4d on Intel E2100](/guides/es2k/running-infrap4d.md) for starting `infrap4d` process and creating protobuf binary for `fxp-net_linux-networking-v3` P4 program.
 
@@ -118,13 +104,6 @@ These VSI values can be checked with `/usr/bin/cli_client -q -c` command on IMC.
 
 Once the application is started, set the forwarding pipeline config using
 P4Runtime Client `p4rt-ctl` set-pipe command
-
-- For Linux Networking v2
-
-  ```bash
-     $P4CP_INSTALL/bin/p4rt-ctl set-pipe br0 $OUTPUT_DIR/fxp-net_linux-networking-v2.pb.bin \
-     $OUTPUT_DIR/p4info.txt
-  ```
 
 - For Linux Networking v3
 
@@ -236,14 +215,6 @@ Example:
 - Overlay VF1 has a VSI value 27, its corresponding port representor has VSI value 9
 - If a VSI is used as an action, add an offset of 16 to the VSI value
 
-- For Linux Networking v2
-
-  ```bash
-     # Create a source port for an overlay VF (VSI-27). Source port value should be VSI ID + 16.
-      p4rt-ctl add-entry br0 linux_networking_control.tx_source_port_v4 \
-      "vmeta.common.vsi=27,zero_padding=0,action=linux_networking_control.set_source_port(43)"
-   ```
-
 - For Linux Networking v3
 
   ```bash
@@ -311,14 +282,6 @@ Example:
 - APF netdev 1 on HOST has a VSI value 24, its corresponding port representor has VSI value 18
 - If a VSI is used as an action, add an offset of 16 to the VSI value
 
-- For Linux Networking v2
-
-  ```bash
-     # Create a source port for an APF netdev (VSI-24). Source port value should be VSI ID + 16.
-      p4rt-ctl add-entry br0 linux_networking_control.tx_source_port_v4 \
-      "vmeta.common.vsi=24,zero_padding=0,action=linux_networking_control.set_source_port(40)"
-   ```
-
 - For Linux Networking v3
 
   ```bash
@@ -350,13 +313,6 @@ Example:
 
 For TCAM entry configure LPM LUT table
 
-- For Linux Networking v2
-
-```bash
- p4rt-ctl add-entry br0 linux_networking_control.ipv4_lpm_root_lut \
-     "user_meta.cmeta.bit32_zeros=4/255.255.255.255,priority=65535,action=linux_networking_control.ipv4_lpm_root_lut_action(0)"
-```
-
 - For Linux Networking v3
 
 ```bash
@@ -365,34 +321,6 @@ For TCAM entry configure LPM LUT table
 ```
 
 Create a dummy LAG bypass table for all 8 hash indexes
-
-- For Linux Networking v2
-
-  ```bash
-     p4rt-ctl add-entry br0  linux_networking_control.tx_lag_table \
-      "user_meta.cmeta.lag_group_id=0,hash=0,action=linux_networking_control.bypass"
-
-     p4rt-ctl add-entry br0  linux_networking_control.tx_lag_table \
-      "user_meta.cmeta.lag_group_id=0,hash=1,action=linux_networking_control.bypass"
-
-     p4rt-ctl add-entry br0  linux_networking_control.tx_lag_table \
-      "user_meta.cmeta.lag_group_id=0,hash=2,action=linux_networking_control.bypass"
-
-     p4rt-ctl add-entry br0  linux_networking_control.tx_lag_table \
-      "user_meta.cmeta.lag_group_id=0,hash=3,action=linux_networking_control.bypass"
-
-     p4rt-ctl add-entry br0  linux_networking_control.tx_lag_table \
-      "user_meta.cmeta.lag_group_id=0,hash=4,action=linux_networking_control.bypass"
-
-     p4rt-ctl add-entry br0  linux_networking_control.tx_lag_table \
-      "user_meta.cmeta.lag_group_id=0,hash=5,action=linux_networking_control.bypass"
-
-     p4rt-ctl add-entry br0  linux_networking_control.tx_lag_table \
-      "user_meta.cmeta.lag_group_id=0,hash=6,action=linux_networking_control.bypass"
-
-     p4rt-ctl add-entry br0  linux_networking_control.tx_lag_table \
-      "user_meta.cmeta.lag_group_id=0,hash=7,action=linux_networking_control.bypass"
-   ```
 
 - For Linux Networking v3
 

--- a/docs/apps/lnw/es2k/es2k-lnw-underlay-ecmp.md
+++ b/docs/apps/lnw/es2k/es2k-lnw-underlay-ecmp.md
@@ -39,7 +39,7 @@ Modify `load_custom_pkg.sh` with following parameters for linux_networking packa
 
      ```text
         sed -i 's/sem_num_pages = 1;/sem_num_pages = 28;/g' $CP_INIT_CFG
-        sed -i 's/lem_num_pages = 1;/lem_num_pages = 10;/g' $CP_INIT_CFG
+        sed -i 's/lem_num_pages = 6;/lem_num_pages = 10;/g' $CP_INIT_CFG
         sed -i 's/mod_num_pages = 1;/mod_num_pages = 2;/g' $CP_INIT_CFG
         sed -i 's/acc_apf = 4;/acc_apf = 16;/g' $CP_INIT_CFG
      ```

--- a/docs/apps/lnw/es2k/es2k-lnw-underlay-frr.md
+++ b/docs/apps/lnw/es2k/es2k-lnw-underlay-frr.md
@@ -39,7 +39,7 @@ Modify `load_custom_pkg.sh` with following parameters for linux_networking packa
 
      ```text
         sed -i 's/sem_num_pages = 1;/sem_num_pages = 28;/g' $CP_INIT_CFG
-        sed -i 's/lem_num_pages = 1;/lem_num_pages = 10;/g' $CP_INIT_CFG
+        sed -i 's/lem_num_pages = 6;/lem_num_pages = 10;/g' $CP_INIT_CFG
         sed -i 's/mod_num_pages = 1;/mod_num_pages = 2;/g' $CP_INIT_CFG
         sed -i 's/acc_apf = 4;/acc_apf = 16;/g' $CP_INIT_CFG
      ```

--- a/docs/apps/lnw/es2k/es2k-lnw-underlay-frr.md
+++ b/docs/apps/lnw/es2k/es2k-lnw-underlay-frr.md
@@ -31,17 +31,6 @@ for more details on this feature.
 
 Prerequisites:
 
-- For Linux Networking v2
-  - Download `hw-p4-programs` TAR file compliant with the CI build image and extract it to get `fxp-net_linux-networking-v2` P4 artifacts. Check `README` for bringup guide, and be sure to check `Limitations` for known issues.
-  - Follow steps mentioned in [Deploying P4 Programs for E2100](/guides/es2k/deploying-p4-programs) for bringing up IPU with a custom P4 package.
-Modify `load_custom_pkg.sh` with following parameters for linux_networking package:
-
-    ```text
-       sed -i 's/sem_num_pages = 1;/sem_num_pages = 25;/g' $CP_INIT_CFG
-       sed -i 's/lem_num_pages = 1;/lem_num_pages = 10;/g' $CP_INIT_CFG
-       sed -i 's/acc_apf = 4;/acc_apf = 16;/g' $CP_INIT_CFG
-    ```
-
 - For Linux Networking v3
   - Download `hw-p4-programs` TAR file compliant with the CI build image and extract it to get `fxp-net_linux-networking-v3` P4 artifacts. Check `README` for bringup guide, and be sure to check `Limitations` for known issues.
 
@@ -82,9 +71,6 @@ System under test will have above topology running the networking recipe. Link P
 
 ## Creating the topology
 
-- For Linux Networking v2
-  Follow steps mentioned in [Running Infrap4d on Intel E2100](/guides/es2k/running-infrap4d.md) for starting `infrap4d` process and creating protobuf binary for `fxp-net_linux-networking-v2` P4 program.
-
 - For Linux Networking v3
   Follow steps mentioned in [Running Infrap4d on Intel E2100](/guides/es2k/running-infrap4d.md) for starting `infrap4d` process and creating protobuf binary for `fxp-net_linux-networking-v3` P4 program.
 
@@ -117,13 +103,6 @@ These VSI values can be checked with `/usr/bin/cli_client -q -c` command on IMC.
 
 Once the application is started, set the forwarding pipeline config using
 P4Runtime Client `p4rt-ctl` set-pipe command
-
-- For Linux Networking v2
-
-  ```bash
-     $P4CP_INSTALL/bin/p4rt-ctl set-pipe br0 $OUTPUT_DIR/fxp-net_linux-networking-v2.pb.bin \
-     $OUTPUT_DIR/p4info.txt
-  ```
 
 - For Linux Networking v3
 
@@ -234,14 +213,6 @@ Example:
 - Overlay VF1 has a VSI value 27, its corresponding port representor has VSI value 9
 - If a VSI is used as an action, add an offset of 16 to the VSI value
 
-- For Linux Networking v2
-
-  ```bash
-     # Create a source port for an overlay VF (VSI-27). Source port value should be VSI ID + 16.
-      p4rt-ctl add-entry br0 linux_networking_control.tx_source_port_v4 \
-      "vmeta.common.vsi=27,zero_padding=0,action=linux_networking_control.set_source_port(43)"
-   ```
-
 - For Linux Networking v3
 
   ```bash
@@ -309,14 +280,6 @@ Example:
 - APF netdev 1 on HOST has a VSI value 24, its corresponding port representor has VSI value 18
 - If a VSI is used as an action, add an offset of 16 to the VSI value
 
-- For Linux Networking v2
-
-  ```bash
-     # Create a source port for an APF netdev (VSI-24). Source port value should be VSI ID + 16.
-      p4rt-ctl add-entry br0 linux_networking_control.tx_source_port_v4 \
-      "vmeta.common.vsi=24,zero_padding=0,action=linux_networking_control.set_source_port(40)"
-   ```
-
 - For Linux Networking v3
 
   ```bash
@@ -348,13 +311,6 @@ Example:
 
 For TCAM entry configure LPM LUT table
 
-- For Linux NEtworking v2
-
-```bash
- p4rt-ctl add-entry br0 linux_networking_control.ipv4_lpm_root_lut \
-     "user_meta.cmeta.bit32_zeros=4/255.255.255.255,priority=65535,action=linux_networking_control.ipv4_lpm_root_lut_action(0)"
-```
-
 - For Linux Networking v3
 
 ```bash
@@ -363,34 +319,6 @@ For TCAM entry configure LPM LUT table
 ```
 
 Create a dummy LAG bypass table for all 8 hash indexes
-
-- For Linux Networking v2
-
-  ```bash
-     p4rt-ctl add-entry br0  linux_networking_control.tx_lag_table \
-      "user_meta.cmeta.lag_group_id=0,hash=0,action=linux_networking_control.bypass"
-
-     p4rt-ctl add-entry br0  linux_networking_control.tx_lag_table \
-      "user_meta.cmeta.lag_group_id=0,hash=1,action=linux_networking_control.bypass"
-
-     p4rt-ctl add-entry br0  linux_networking_control.tx_lag_table \
-      "user_meta.cmeta.lag_group_id=0,hash=2,action=linux_networking_control.bypass"
-
-     p4rt-ctl add-entry br0  linux_networking_control.tx_lag_table \
-      "user_meta.cmeta.lag_group_id=0,hash=3,action=linux_networking_control.bypass"
-
-     p4rt-ctl add-entry br0  linux_networking_control.tx_lag_table \
-      "user_meta.cmeta.lag_group_id=0,hash=4,action=linux_networking_control.bypass"
-
-     p4rt-ctl add-entry br0  linux_networking_control.tx_lag_table \
-      "user_meta.cmeta.lag_group_id=0,hash=5,action=linux_networking_control.bypass"
-
-     p4rt-ctl add-entry br0  linux_networking_control.tx_lag_table \
-      "user_meta.cmeta.lag_group_id=0,hash=6,action=linux_networking_control.bypass"
-
-     p4rt-ctl add-entry br0  linux_networking_control.tx_lag_table \
-      "user_meta.cmeta.lag_group_id=0,hash=7,action=linux_networking_control.bypass"
-   ```
 
 - For Linux Networking v3
 

--- a/docs/apps/lnw/es2k/es2k-lnw-underlay-lag.md
+++ b/docs/apps/lnw/es2k/es2k-lnw-underlay-lag.md
@@ -39,7 +39,7 @@ Modify `load_custom_pkg.sh` with following parameters for linux_networking packa
 
      ```text
         sed -i 's/sem_num_pages = 1;/sem_num_pages = 28;/g' $CP_INIT_CFG
-        sed -i 's/lem_num_pages = 1;/lem_num_pages = 10;/g' $CP_INIT_CFG
+        sed -i 's/lem_num_pages = 6;/lem_num_pages = 10;/g' $CP_INIT_CFG
         sed -i 's/allow_change_mac_address = false;/allow_change_mac_address = true;/g' $CP_INIT_CFG
         sed -i 's/acc_apf = 4;/acc_apf = 16;/g' $CP_INIT_CFG
 

--- a/docs/apps/lnw/es2k/es2k-lnw-underlay-lag.md
+++ b/docs/apps/lnw/es2k/es2k-lnw-underlay-lag.md
@@ -31,17 +31,6 @@ for more details on this feature.
 
 Prerequisites:
 
-- For Linux Networking v2
-  - Download `hw-p4-programs` TAR file compliant with the CI build image and extract it to get `fxp-net_linux-networking-v2` P4 artifacts. Check `README` for bringup guide, and be sure to check `Limitations` for known issues.
-  - Follow steps mentioned in [Deploying P4 Programs for E2100](/guides/es2k/deploying-p4-programs) for bringing up IPU with a custom P4 package.
-Modify `load_custom_pkg.sh` with following parameters for linux_networking package:
-
-    ```text
-       sed -i 's/sem_num_pages = 1;/sem_num_pages = 25;/g' $CP_INIT_CFG
-       sed -i 's/lem_num_pages = 1;/lem_num_pages = 10;/g' $CP_INIT_CFG
-       sed -i 's/acc_apf = 4;/acc_apf = 16;/g' $CP_INIT_CFG
-    ```
-
 - For Linux Networking v3
   - Download `hw-p4-programs` TAR file compliant with the CI build image and extract it to get `fxp-net_linux-networking-v3` P4 artifacts. Check readme for bring up guide, and be sure to check limitation for known issues.
 
@@ -84,9 +73,6 @@ System under test will have above topology running the networking recipe. Link P
 
 ## Creating the topology
 
-- For Linux Networking v2
-  Follow steps mentioned in [Running Infrap4d on Intel E2100](/guides/es2k/running-infrap4d.md) for starting `infrap4d` process and creating protobuf binary for `fxp-net_linux-networking-v2` P4 program.
-
 - For Linux Networking v3
   Follow steps mentioned in [Running Infrap4d on Intel E2100](/guides/es2k/running-infrap4d.md) for starting `infrap4d` process and creating protobuf binary for `fxp-net_linux-networking-v3` P4 program.
 
@@ -120,13 +106,6 @@ These VSI values can be checked with `/usr/bin/cli_client -q -c` command on IMC.
 Once the application is started, set the forwarding pipeline config using
 P4Runtime Client `p4rt-ctl` set-pipe command
 
-- For Linux Networking v2
-
-  ```bash
-     $P4CP_INSTALL/bin/p4rt-ctl set-pipe br0 $OUTPUT_DIR/fxp-net_linux-networking-v2.pb.bin \
-     $OUTPUT_DIR/p4info.txt
-  ```
-
 - For Linux Networking v3
 
   ```bash
@@ -134,7 +113,7 @@ P4Runtime Client `p4rt-ctl` set-pipe command
      $OUTPUT_DIR/p4info.txt
   ```
 
-Note: Assumes that `fxp-net_linux-networking-v2.pb.bin`, `p4info.txt` and other P4 artifacts, are created by following the steps in the previous section.
+Note: Assumes that `fxp-net_linux-networking-v3.pb.bin`, `p4info.txt` and other P4 artifacts, are created by following the steps in the previous section.
 
 ### Configure VSI Group and add a netdev
 
@@ -237,14 +216,6 @@ Example:
 - Overlay VF1 has a VSI value 27, its corresponding port representor has VSI value 9
 - If a VSI is used as an action, add an offset of 16 to the VSI value
 
-- For Linux Networking v2
-
-  ```bash
-     # Create a source port for an overlay VF (VSI-27). Source port value should be VSI ID + 16.
-      p4rt-ctl add-entry br0 linux_networking_control.tx_source_port_v4 \
-      "vmeta.common.vsi=27,zero_padding=0,action=linux_networking_control.set_source_port(43)"
-   ```
-
 - For Linux Networking v3
 
   ```bash
@@ -312,14 +283,6 @@ Example:
 - APF netdev 1 on HOST has a VSI value 24, its corresponding port representor has VSI value 18
 - If a VSI is used as an action, add an offset of 16 to the VSI value
 
-- For Linux Networking v2
-
-  ```bash
-     # Create a source port for an APF netdev (VSI-24). Source port value should be VSI ID + 16.
-      p4rt-ctl add-entry br0 linux_networking_control.tx_source_port_v4 \
-      "vmeta.common.vsi=24,zero_padding=0,action=linux_networking_control.set_source_port(40)"
-   ```
-
 - For Linux Networking v3
 
   ```bash
@@ -350,13 +313,6 @@ Example:
 ### Configure supporting p4 runtime tables
 
 For TCAM entry configure LPM LUT table
-
-- For Linux Networking v2
-
-```bash
- p4rt-ctl add-entry br0 linux_networking_control.ipv4_lpm_root_lut \
-     "user_meta.cmeta.bit32_zeros=4/255.255.255.255,priority=65535,action=linux_networking_control.ipv4_lpm_root_lut_action(0)"
-```
 
 - For Linux Networking v3
 


### PR DESCRIPTION
Linux Networking v2 is no long supported and users are expected to use Linux Networking v3 instead.

Removing all references to LNWv2 from the guide book.