### PR TITLE
Clarification on ipv6 support in lnw_v3

### DIFF
--- a/docs/apps/lnw/es2k/es2k-linux-networking.md
+++ b/docs/apps/lnw/es2k/es2k-linux-networking.md
@@ -306,4 +306,4 @@ Current Linux Networking support for the networking recipe has the following lim
   `vm_dst_ip4_mac_map_table` since entries in these tables are learnt from OVS flows in MAC learning phase
   and OVS might not issue a callback to delete these unless aging happens. Delete these enties using
   `p4rt-ctl del-entry` command
-- IPv6 is not supported
+- IPv6 as part of IPsec tunnel configuration is not supported


### PR DESCRIPTION
Original comment simply said IPv6 not supported. Clarification that networking portion is supported. It is only the IPsec tunneling portion that does not support IPv6 in LNWv3