### PR TITLE
Remove v3 tag from LNW name

### DIFF
--- a/docs/apps/lnw/es2k/es2k-linux-networking.md
+++ b/docs/apps/lnw/es2k/es2k-linux-networking.md
@@ -299,9 +299,6 @@ Current Linux Networking support for the networking recipe has the following lim
 - LAG and ECMP are mutually exclusive. Both can't co-exist in the system configuration at the same time.
 - LAG configuration done via bonding driver is supported.
 - The supported modes are active-backup and active-active with 802.3ad (LACP).
-
-## Additional limitations for Linux Networking v3
-
 - After teardown, it's possible that entries continue to exist in `vm_src_ip4_mac_map_table` and
   `vm_dst_ip4_mac_map_table` since entries in these tables are learnt from OVS flows in MAC learning phase
   and OVS might not issue a callback to delete these unless aging happens. Delete these enties using

--- a/docs/apps/lnw/es2k/es2k-lnw-overlay-ipv6.md
+++ b/docs/apps/lnw/es2k/es2k-lnw-overlay-ipv6.md
@@ -31,18 +31,19 @@ for more details on this feature.
 
 Prerequisites:
 
-- For Linux Networking v3
-  - Download `hw-p4-programs` TAR file compliant with the CI build image and extract it to get `fxp-net_linux-networking-v3` P4 artifacts. Check readme for bring up guide, and be sure to check limitation for known issues.
+- For Linux Networking
+  - Download `hw-p4-programs` TAR file compliant with the CI build image and extract it to get `fxp-net_linux-networking` P4 artifacts. Check readme for bring up guide, and be sure to check limitation for known issues.
 
   - Follow steps mentioned in [Deploying P4 Programs for E2100](/guides/es2k/deploying-p4-programs) for bringing up IPU with a custom P4 package.
 Modify `load_custom_pkg.sh` with following parameters for linux_networking package:
 
-     ```bash
-    sed -i 's/sem_num_pages = 1;/sem_num_pages = 28;/g' $CP_INIT_CFG
-    sed -i 's/lem_num_pages = 6;/lem_num_pages = 10;/g' $CP_INIT_CFG
-    sed -i 's/allow_change_mac_address = false;/allow_change_mac_address = true;/g' $CP_INIT_CFG
-    sed -i 's/acc_apf = 4;/acc_apf = 16;/g' $CP_INIT_CFG
-    ```
+     ```text
+        sed -i 's/sem_num_pages = .*;/sem_num_pages = 28;/g' $CP_INIT_CFG
+        sed -i 's/lem_num_pages = .*;/lem_num_pages = 10;/g' $CP_INIT_CFG
+        sed -i 's/mod_num_pages = .*;/mod_num_pages = 2;/g' $CP_INIT_CFG
+        sed -i 's/allow_change_mac_address = false;/allow_change_mac_address = true;/g' $CP_INIT_CFG
+        sed -i 's/acc_apf = 4;/acc_apf = 16;/g' $CP_INIT_CFG
+     ```
 
 - Download `IPU_Documentation` TAR file compliant with the CI build image and refer to `Getting Started Guide` on how to install compatible `IDPF driver` on host. Once an IDPF driver is installed, bring up SRIOV VF by modifying the `sriov_numvfs` file present under one of the IDPF network devices. Example as below
 
@@ -71,8 +72,7 @@ System under test will have above topology running the networking recipe. Link P
 
 ## Creating the topology
 
-- For Linux Networking v3
-  Follow steps mentioned in [Running Infrap4d on Intel E2100](/guides/es2k/running-infrap4d.md) for starting `infrap4d` process and creating protobuf binary for `fxp-net_linux-networking-v3` P4 program.
+Follow steps mentioned in [Running Infrap4d on Intel E2100](/guides/es2k/running-infrap4d.md) for starting `infrap4d` process and creating protobuf binary for `fxp-net_linux-networking` P4 program.
 
 ### Port mapping
 
@@ -104,13 +104,11 @@ These VSI values can be checked with `/usr/bin/cli_client -q -c` command on IMC.
 Once the application is started, set the forwarding pipeline config using
 P4Runtime Client `p4rt-ctl` set-pipe command
 
-- For Linux Networking v3
-
     ```bash
-    $P4CP_INSTALL/bin/p4rt-ctl set-pipe br0 $OUTPUT_DIR/fxp-net_linux-networking-v3.pb.bin $OUTPUT_DIR/p4info.txt
+    $P4CP_INSTALL/bin/p4rt-ctl set-pipe br0 $OUTPUT_DIR/fxp-net_linux-networking.pb.bin $OUTPUT_DIR/p4info.txt
     ```
 
-Note: Assumes that `fxp-net_linux-networking-v3.pb.bin`, `p4info.txt` and other P4 artifacts, are created by following the steps in the previous section.
+Note: Assumes that `fxp-net_linux-networking.pb.bin`, `p4info.txt` and other P4 artifacts, are created by following the steps in the previous section.
 
 ### Configure VSI Group and add a netdev
 

--- a/docs/apps/lnw/es2k/es2k-lnw-overlay-ipv6.md
+++ b/docs/apps/lnw/es2k/es2k-lnw-overlay-ipv6.md
@@ -104,9 +104,9 @@ These VSI values can be checked with `/usr/bin/cli_client -q -c` command on IMC.
 Once the application is started, set the forwarding pipeline config using
 P4Runtime Client `p4rt-ctl` set-pipe command
 
-    ```bash
-    $P4CP_INSTALL/bin/p4rt-ctl set-pipe br0 $OUTPUT_DIR/fxp-net_linux-networking.pb.bin $OUTPUT_DIR/p4info.txt
-    ```
+```bash
+$P4CP_INSTALL/bin/p4rt-ctl set-pipe br0 $OUTPUT_DIR/fxp-net_linux-networking.pb.bin $OUTPUT_DIR/p4info.txt
+```
 
 Note: Assumes that `fxp-net_linux-networking.pb.bin`, `p4info.txt` and other P4 artifacts, are created by following the steps in the previous section.
 

--- a/docs/apps/lnw/es2k/es2k-lnw-overlay-ipv6.md
+++ b/docs/apps/lnw/es2k/es2k-lnw-overlay-ipv6.md
@@ -37,7 +37,7 @@ Prerequisites:
   - Follow steps mentioned in [Deploying P4 Programs for E2100](/guides/es2k/deploying-p4-programs) for bringing up IPU with a custom P4 package.
 Modify `load_custom_pkg.sh` with following parameters for linux_networking package:
 
-     ```text
+     ```bash
         sed -i 's/sem_num_pages = .*;/sem_num_pages = 28;/g' $CP_INIT_CFG
         sed -i 's/lem_num_pages = .*;/lem_num_pages = 10;/g' $CP_INIT_CFG
         sed -i 's/mod_num_pages = .*;/mod_num_pages = 2;/g' $CP_INIT_CFG

--- a/docs/apps/lnw/es2k/es2k-lnw-overlay-vms.md
+++ b/docs/apps/lnw/es2k/es2k-lnw-overlay-vms.md
@@ -68,7 +68,7 @@ System under test will have above topology running the networking recipe. Link P
 
 ## Creating the topology
 
-  Follow steps mentioned in [Running Infrap4d on Intel E2100](/guides/es2k/running-infrap4d.md) for starting `infrap4d` process and creating protobuf binary for `fxp-net_linux-networking` P4 program.
+Follow steps mentioned in [Running Infrap4d on Intel E2100](/guides/es2k/running-infrap4d.md) for starting `infrap4d` process and creating protobuf binary for `fxp-net_linux-networking` P4 program.
 
 ### Port Mapping
 

--- a/docs/apps/lnw/es2k/es2k-lnw-overlay-vms.md
+++ b/docs/apps/lnw/es2k/es2k-lnw-overlay-vms.md
@@ -36,7 +36,7 @@ Prerequisites:
   - Follow steps mentioned in [Deploying P4 Programs for E2100](/guides/es2k/deploying-p4-programs) for bringing up IPU with a custom P4 package.
 Modify `load_custom_pkg.sh` with following parameters for linux_networking package:
 
-     ```text
+     ```bash
         sed -i 's/sem_num_pages = .*;/sem_num_pages = 28;/g' $CP_INIT_CFG
         sed -i 's/lem_num_pages = .*;/lem_num_pages = 10;/g' $CP_INIT_CFG
         sed -i 's/mod_num_pages = .*;/mod_num_pages = 2;/g' $CP_INIT_CFG

--- a/docs/apps/lnw/es2k/es2k-lnw-overlay-vms.md
+++ b/docs/apps/lnw/es2k/es2k-lnw-overlay-vms.md
@@ -31,15 +31,15 @@ for more details on this feature.
 
 Prerequisites:
 
-- For Linux Networking v3
-  - Download `hw-p4-programs` TAR file compliant with the CI build image and extract it to get `fxp-net_linux-networking-v3` P4 artifacts. Check `README` for bringup guide, and be sure to check `Limitations` for known issues.
+- For Linux Networking
+  - Download `hw-p4-programs` TAR file compliant with the CI build image and extract it to get `fxp-net_linux-networking` P4 artifacts. Check `README` for bringup guide, and be sure to check `Limitations` for known issues.
   - Follow steps mentioned in [Deploying P4 Programs for E2100](/guides/es2k/deploying-p4-programs) for bringing up IPU with a custom P4 package.
 Modify `load_custom_pkg.sh` with following parameters for linux_networking package:
 
      ```text
-        sed -i 's/sem_num_pages = 1;/sem_num_pages = 28;/g' $CP_INIT_CFG
-        sed -i 's/lem_num_pages = 6;/lem_num_pages = 10;/g' $CP_INIT_CFG
-        sed -i 's/mod_num_pages = 1;/mod_num_pages = 2;/g' $CP_INIT_CFG
+        sed -i 's/sem_num_pages = .*;/sem_num_pages = 28;/g' $CP_INIT_CFG
+        sed -i 's/lem_num_pages = .*;/lem_num_pages = 10;/g' $CP_INIT_CFG
+        sed -i 's/mod_num_pages = .*;/mod_num_pages = 2;/g' $CP_INIT_CFG
         sed -i 's/acc_apf = 4;/acc_apf = 16;/g' $CP_INIT_CFG
      ```
 
@@ -68,8 +68,7 @@ System under test will have above topology running the networking recipe. Link P
 
 ## Creating the topology
 
-- For Linux Networking v3
-  Follow steps mentioned in [Running Infrap4d on Intel E2100](/guides/es2k/running-infrap4d.md) for starting `infrap4d` process and creating protobuf binary for `fxp-net_linux-networking-v3` P4 program.
+  Follow steps mentioned in [Running Infrap4d on Intel E2100](/guides/es2k/running-infrap4d.md) for starting `infrap4d` process and creating protobuf binary for `fxp-net_linux-networking` P4 program.
 
 ### Port Mapping
 
@@ -108,10 +107,8 @@ These VSI values can be checked with `/usr/bin/cli_client -q -c` command on IMC.
 Once the application is started, set the forwarding pipeline config using
 P4Runtime Client `p4rt-ctl` set-pipe command
 
-- For Linux Networking v3
-
   ```bash
-     $P4CP_INSTALL/bin/p4rt-ctl set-pipe br0 $OUTPUT_DIR/fxp-net_linux-networking-v3.pb.bin \
+     $P4CP_INSTALL/bin/p4rt-ctl set-pipe br0 $OUTPUT_DIR/fxp-net_linux-networking.pb.bin \
      $OUTPUT_DIR/p4info.txt
   ```
 
@@ -220,8 +217,6 @@ Example:
 - Corresponding port representor VSI value 9
 - If a VSI is used as an action, add an offset of 16 to the VSI value
 
-- For Linux Networking v3
-
   ```bash
      # Create a source port for an overlay VF (VSI-27). Source port value should be VSI ID + 16.
       p4rt-ctl add-entry br0 linux_networking_control.tx_source_port_v4 \
@@ -288,8 +283,6 @@ Example:
 - Corresponding port representor VSI value 18
 - If a VSI is used as an action, add an offset of 16 to the VSI value
 
-- For Linux Networking v3
-
   ```bash
      # Create a source port for an APF netdev (VSI-24). Source port value should be VSI ID + 16.
       p4rt-ctl add-entry br0 linux_networking_control.tx_source_port_v4 \
@@ -318,16 +311,12 @@ Example:
 
 For TCAM entry configure LPM LUT table
 
-- For Linux Networking v3
-
 ```bash
  p4rt-ctl add-entry br0 linux_networking_control.ipv4_lpm_root_lut \
      "user_meta.cmeta.bit16_zeros=4/65535,priority=2048,action=linux_networking_control.ipv4_lpm_root_lut_action(0)"
 ```
 
 Create a dummy LAG bypass table for all 8 hash indexes
-
-- For Linux Networking v3
 
   ```bash
      p4rt-ctl add-entry br0  linux_networking_control.tx_lag_table \

--- a/docs/apps/lnw/es2k/es2k-lnw-underlay-ecmp.md
+++ b/docs/apps/lnw/es2k/es2k-lnw-underlay-ecmp.md
@@ -31,16 +31,16 @@ for more details on this feature.
 
 Prerequisites:
 
-- For Linux Networking v3
-  - Download `hw-p4-programs` TAR file compliant with the CI build image and extract it to get `fxp-net_linux-networking-v3` P4 artifacts. Check `README` for bringup guide, and be sure to check `Limitations` for known issues.
+- For Linux Networking
+  - Download `hw-p4-programs` TAR file compliant with the CI build image and extract it to get `fxp-net_linux-networking` P4 artifacts. Check `README` for bringup guide, and be sure to check `Limitations` for known issues.
 
   - Follow steps mentioned in [Deploying P4 Programs for E2100](/guides/es2k/deploying-p4-programs) for bringing up IPU with a custom P4 package.
 Modify `load_custom_pkg.sh` with following parameters for linux_networking package:
 
      ```text
-        sed -i 's/sem_num_pages = 1;/sem_num_pages = 28;/g' $CP_INIT_CFG
-        sed -i 's/lem_num_pages = 6;/lem_num_pages = 10;/g' $CP_INIT_CFG
-        sed -i 's/mod_num_pages = 1;/mod_num_pages = 2;/g' $CP_INIT_CFG
+        sed -i 's/sem_num_pages = .*;/sem_num_pages = 28;/g' $CP_INIT_CFG
+        sed -i 's/lem_num_pages = .*;/lem_num_pages = 10;/g' $CP_INIT_CFG
+        sed -i 's/mod_num_pages = .*;/mod_num_pages = 2;/g' $CP_INIT_CFG
         sed -i 's/acc_apf = 4;/acc_apf = 16;/g' $CP_INIT_CFG
      ```
 
@@ -71,8 +71,8 @@ System under test will have above topology running the networking recipe. Link P
 
 ## Creating the topology
 
-- For Linux Networking v3
-  Follow steps mentioned in [Running Infrap4d on Intel E2100](/guides/es2k/running-infrap4d.md) for starting `infrap4d` process and creating protobuf binary for `fxp-net_linux-networking-v3` P4 program.
+- For Linux Networking
+  Follow steps mentioned in [Running Infrap4d on Intel E2100](/guides/es2k/running-infrap4d.md) for starting `infrap4d` process and creating protobuf binary for `fxp-net_linux-networking` P4 program.
 
 ### Port mapping
 
@@ -105,10 +105,8 @@ These VSI values can be checked with `/usr/bin/cli_client -q -c` command on IMC.
 Once the application is started, set the forwarding pipeline config using
 P4Runtime Client `p4rt-ctl` set-pipe command
 
-- For Linux Networking v3
-
   ```bash
-     $P4CP_INSTALL/bin/p4rt-ctl set-pipe br0 $OUTPUT_DIR/fxp-net_linux-networking-v3.pb.bin \
+     $P4CP_INSTALL/bin/p4rt-ctl set-pipe br0 $OUTPUT_DIR/fxp-net_linux-networking.pb.bin \
      $OUTPUT_DIR/p4info.txt
   ```
 
@@ -215,8 +213,6 @@ Example:
 - Overlay VF1 has a VSI value 27, its corresponding port representor has VSI value 9
 - If a VSI is used as an action, add an offset of 16 to the VSI value
 
-- For Linux Networking v3
-
   ```bash
      # Create a source port for an overlay VF (VSI-27). Source port value should be VSI ID + 16.
       p4rt-ctl add-entry br0 linux_networking_control.tx_source_port_v4 \
@@ -282,7 +278,7 @@ Example:
 - APF netdev 1 on HOST has a VSI value 24, its corresponding port representor has VSI value 18
 - If a VSI is used as an action, add an offset of 16 to the VSI value
 
-- For Linux Networking v3
+- For Linux Networking
 
   ```bash
      # Create a source port for an APF netdev (VSI-24). Source port value should be VSI ID + 16.
@@ -313,16 +309,12 @@ Example:
 
 For TCAM entry configure LPM LUT table
 
-- For Linux Networking v3
-
 ```bash
  p4rt-ctl add-entry br0 linux_networking_control.ipv4_lpm_root_lut \
      "user_meta.cmeta.bit16_zeros=4/65535,priority=2048,action=linux_networking_control.ipv4_lpm_root_lut_action(0)"
 ```
 
 Create a dummy LAG bypass table for all 8 hash indexes
-
-- For Linux Networking v3
 
   ```bash
      p4rt-ctl add-entry br0  linux_networking_control.tx_lag_table \

--- a/docs/apps/lnw/es2k/es2k-lnw-underlay-ecmp.md
+++ b/docs/apps/lnw/es2k/es2k-lnw-underlay-ecmp.md
@@ -37,7 +37,7 @@ Prerequisites:
   - Follow steps mentioned in [Deploying P4 Programs for E2100](/guides/es2k/deploying-p4-programs) for bringing up IPU with a custom P4 package.
 Modify `load_custom_pkg.sh` with following parameters for linux_networking package:
 
-     ```text
+     ```bash
         sed -i 's/sem_num_pages = .*;/sem_num_pages = 28;/g' $CP_INIT_CFG
         sed -i 's/lem_num_pages = .*;/lem_num_pages = 10;/g' $CP_INIT_CFG
         sed -i 's/mod_num_pages = .*;/mod_num_pages = 2;/g' $CP_INIT_CFG

--- a/docs/apps/lnw/es2k/es2k-lnw-underlay-frr.md
+++ b/docs/apps/lnw/es2k/es2k-lnw-underlay-frr.md
@@ -31,16 +31,16 @@ for more details on this feature.
 
 Prerequisites:
 
-- For Linux Networking v3
-  - Download `hw-p4-programs` TAR file compliant with the CI build image and extract it to get `fxp-net_linux-networking-v3` P4 artifacts. Check `README` for bringup guide, and be sure to check `Limitations` for known issues.
+- For Linux Networking
+  - Download `hw-p4-programs` TAR file compliant with the CI build image and extract it to get `fxp-net_linux-networking` P4 artifacts. Check `README` for bringup guide, and be sure to check `Limitations` for known issues.
 
   - Follow steps mentioned in [Deploying P4 Programs for E2100](/guides/es2k/deploying-p4-programs) for bringing up IPU with a custom P4 package.
 Modify `load_custom_pkg.sh` with following parameters for linux_networking package:
 
      ```text
-        sed -i 's/sem_num_pages = 1;/sem_num_pages = 28;/g' $CP_INIT_CFG
-        sed -i 's/lem_num_pages = 6;/lem_num_pages = 10;/g' $CP_INIT_CFG
-        sed -i 's/mod_num_pages = 1;/mod_num_pages = 2;/g' $CP_INIT_CFG
+        sed -i 's/sem_num_pages = .*;/sem_num_pages = 28;/g' $CP_INIT_CFG
+        sed -i 's/lem_num_pages = .*;/lem_num_pages = 10;/g' $CP_INIT_CFG
+        sed -i 's/mod_num_pages = .*;/mod_num_pages = 2;/g' $CP_INIT_CFG
         sed -i 's/acc_apf = 4;/acc_apf = 16;/g' $CP_INIT_CFG
      ```
 
@@ -71,8 +71,7 @@ System under test will have above topology running the networking recipe. Link P
 
 ## Creating the topology
 
-- For Linux Networking v3
-  Follow steps mentioned in [Running Infrap4d on Intel E2100](/guides/es2k/running-infrap4d.md) for starting `infrap4d` process and creating protobuf binary for `fxp-net_linux-networking-v3` P4 program.
+Follow steps mentioned in [Running Infrap4d on Intel E2100](/guides/es2k/running-infrap4d.md) for starting `infrap4d` process and creating protobuf binary for `fxp-net_linux-networking` P4 program.
 
 ### Port mapping
 
@@ -104,10 +103,8 @@ These VSI values can be checked with `/usr/bin/cli_client -q -c` command on IMC.
 Once the application is started, set the forwarding pipeline config using
 P4Runtime Client `p4rt-ctl` set-pipe command
 
-- For Linux Networking v3
-
   ```bash
-     $P4CP_INSTALL/bin/p4rt-ctl set-pipe br0 $OUTPUT_DIR/fxp-net_linux-networking-v3.pb.bin \
+     $P4CP_INSTALL/bin/p4rt-ctl set-pipe br0 $OUTPUT_DIR/fxp-net_linux-networking.pb.bin \
      $OUTPUT_DIR/p4info.txt
 
 Note: Assumes that `pb.bin`, `p4info.txt` and other P4 artifacts, are created by following the steps in the previous section.
@@ -213,8 +210,6 @@ Example:
 - Overlay VF1 has a VSI value 27, its corresponding port representor has VSI value 9
 - If a VSI is used as an action, add an offset of 16 to the VSI value
 
-- For Linux Networking v3
-
   ```bash
      # Create a source port for an overlay VF (VSI-27). Source port value should be VSI ID + 16.
       p4rt-ctl add-entry br0 linux_networking_control.tx_source_port_v4 \
@@ -280,8 +275,6 @@ Example:
 - APF netdev 1 on HOST has a VSI value 24, its corresponding port representor has VSI value 18
 - If a VSI is used as an action, add an offset of 16 to the VSI value
 
-- For Linux Networking v3
-
   ```bash
      # Create a source port for an APF netdev (VSI-24). Source port value should be VSI ID + 16.
       p4rt-ctl add-entry br0 linux_networking_control.tx_source_port_v4 \
@@ -311,16 +304,12 @@ Example:
 
 For TCAM entry configure LPM LUT table
 
-- For Linux Networking v3
-
 ```bash
  p4rt-ctl add-entry br0 linux_networking_control.ipv4_lpm_root_lut \
      "user_meta.cmeta.bit16_zeros=4/65535,priority=2048,action=linux_networking_control.ipv4_lpm_root_lut_action(0)"
 ```
 
 Create a dummy LAG bypass table for all 8 hash indexes
-
-- For Linux Networking v3
 
   ```bash
      p4rt-ctl add-entry br0  linux_networking_control.tx_lag_table \

--- a/docs/apps/lnw/es2k/es2k-lnw-underlay-frr.md
+++ b/docs/apps/lnw/es2k/es2k-lnw-underlay-frr.md
@@ -37,7 +37,7 @@ Prerequisites:
   - Follow steps mentioned in [Deploying P4 Programs for E2100](/guides/es2k/deploying-p4-programs) for bringing up IPU with a custom P4 package.
 Modify `load_custom_pkg.sh` with following parameters for linux_networking package:
 
-     ```text
+     ```bash
         sed -i 's/sem_num_pages = .*;/sem_num_pages = 28;/g' $CP_INIT_CFG
         sed -i 's/lem_num_pages = .*;/lem_num_pages = 10;/g' $CP_INIT_CFG
         sed -i 's/mod_num_pages = .*;/mod_num_pages = 2;/g' $CP_INIT_CFG

--- a/docs/apps/lnw/es2k/es2k-lnw-underlay-lag.md
+++ b/docs/apps/lnw/es2k/es2k-lnw-underlay-lag.md
@@ -31,17 +31,19 @@ for more details on this feature.
 
 Prerequisites:
 
-- For Linux Networking v3
-  - Download `hw-p4-programs` TAR file compliant with the CI build image and extract it to get `fxp-net_linux-networking-v3` P4 artifacts. Check readme for bring up guide, and be sure to check limitation for known issues.
+- For Linux Networking
+  - Download `hw-p4-programs` TAR file compliant with the CI build image and extract it to get `fxp-net_linux-networking` P4 artifacts. Check readme for bring up guide, and be sure to check limitation for known issues.
 
   - Follow steps mentioned in [Deploying P4 Programs for E2100](/guides/es2k/deploying-p4-programs) for bringing up IPU with a custom P4 package.
 Modify `load_custom_pkg.sh` with following parameters for linux_networking package:
 
      ```text
-        sed -i 's/sem_num_pages = 1;/sem_num_pages = 28;/g' $CP_INIT_CFG
-        sed -i 's/lem_num_pages = 6;/lem_num_pages = 10;/g' $CP_INIT_CFG
+        sed -i 's/sem_num_pages = .*;/sem_num_pages = 28;/g' $CP_INIT_CFG
+        sed -i 's/lem_num_pages = .*;/lem_num_pages = 10;/g' $CP_INIT_CFG
+        sed -i 's/mod_num_pages = .*;/mod_num_pages = 2;/g' $CP_INIT_CFG
         sed -i 's/allow_change_mac_address = false;/allow_change_mac_address = true;/g' $CP_INIT_CFG
         sed -i 's/acc_apf = 4;/acc_apf = 16;/g' $CP_INIT_CFG
+     ```
 
 - Download `IPU_Documentation` TAR file compliant with the CI build image and refer to `Getting Started Guide` on how to install compatible `IDPF driver` on host. Once an IDPF driver is installed, bring up SRIOV VF by modifying the `sriov_numvfs` file present under one of the IDPF network devices. Example as below
 
@@ -73,8 +75,7 @@ System under test will have above topology running the networking recipe. Link P
 
 ## Creating the topology
 
-- For Linux Networking v3
-  Follow steps mentioned in [Running Infrap4d on Intel E2100](/guides/es2k/running-infrap4d.md) for starting `infrap4d` process and creating protobuf binary for `fxp-net_linux-networking-v3` P4 program.
+Follow steps mentioned in [Running Infrap4d on Intel E2100](/guides/es2k/running-infrap4d.md) for starting `infrap4d` process and creating protobuf binary for `fxp-net_linux-networking` P4 program.
 
 ### Port mapping
 
@@ -106,14 +107,12 @@ These VSI values can be checked with `/usr/bin/cli_client -q -c` command on IMC.
 Once the application is started, set the forwarding pipeline config using
 P4Runtime Client `p4rt-ctl` set-pipe command
 
-- For Linux Networking v3
-
   ```bash
-     $P4CP_INSTALL/bin/p4rt-ctl set-pipe br0 $OUTPUT_DIR/fxp-net_linux-networking-v3.pb.bin \
+     $P4CP_INSTALL/bin/p4rt-ctl set-pipe br0 $OUTPUT_DIR/fxp-net_linux-networking.pb.bin \
      $OUTPUT_DIR/p4info.txt
   ```
 
-Note: Assumes that `fxp-net_linux-networking-v3.pb.bin`, `p4info.txt` and other P4 artifacts, are created by following the steps in the previous section.
+Note: Assumes that `fxp-net_linux-networking.pb.bin`, `p4info.txt` and other P4 artifacts, are created by following the steps in the previous section.
 
 ### Configure VSI Group and add a netdev
 
@@ -216,8 +215,6 @@ Example:
 - Overlay VF1 has a VSI value 27, its corresponding port representor has VSI value 9
 - If a VSI is used as an action, add an offset of 16 to the VSI value
 
-- For Linux Networking v3
-
   ```bash
      # Create a source port for an overlay VF (VSI-27). Source port value should be VSI ID + 16.
       p4rt-ctl add-entry br0 linux_networking_control.tx_source_port_v4 \
@@ -283,8 +280,6 @@ Example:
 - APF netdev 1 on HOST has a VSI value 24, its corresponding port representor has VSI value 18
 - If a VSI is used as an action, add an offset of 16 to the VSI value
 
-- For Linux Networking v3
-
   ```bash
      # Create a source port for an APF netdev (VSI-24). Source port value should be VSI ID + 16.
       p4rt-ctl add-entry br0 linux_networking_control.tx_source_port_v4 \
@@ -313,8 +308,6 @@ Example:
 ### Configure supporting p4 runtime tables
 
 For TCAM entry configure LPM LUT table
-
-- For Linux Networking v3
 
 ```bash
  p4rt-ctl add-entry br0 linux_networking_control.ipv4_lpm_root_lut \

--- a/docs/apps/lnw/es2k/es2k-lnw-underlay-lag.md
+++ b/docs/apps/lnw/es2k/es2k-lnw-underlay-lag.md
@@ -37,7 +37,7 @@ Prerequisites:
   - Follow steps mentioned in [Deploying P4 Programs for E2100](/guides/es2k/deploying-p4-programs) for bringing up IPU with a custom P4 package.
 Modify `load_custom_pkg.sh` with following parameters for linux_networking package:
 
-     ```text
+     ```bash
         sed -i 's/sem_num_pages = .*;/sem_num_pages = 28;/g' $CP_INIT_CFG
         sed -i 's/lem_num_pages = .*;/lem_num_pages = 10;/g' $CP_INIT_CFG
         sed -i 's/mod_num_pages = .*;/mod_num_pages = 2;/g' $CP_INIT_CFG


### PR DESCRIPTION
The Linux Networking P4 program name has changed to remove the `-v3` version info. Updating all documentation to remove this. We will only refer to the program as "Linux Networking" 