### PR TITLE
Update docs to use increase number of lem num pages in node config file

### DIFF
--- a/docs/apps/lnw/es2k/es2k-lnw-overlay-ipv6.md
+++ b/docs/apps/lnw/es2k/es2k-lnw-overlay-ipv6.md
@@ -39,7 +39,7 @@ Modify `load_custom_pkg.sh` with following parameters for linux_networking packa
 
      ```bash
         sed -i 's/sem_num_pages = .*;/sem_num_pages = 28;/g' $CP_INIT_CFG
-        sed -i 's/lem_num_pages = .*;/lem_num_pages = 10;/g' $CP_INIT_CFG
+        sed -i 's/lem_num_pages = .*;/lem_num_pages = 32;/g' $CP_INIT_CFG
         sed -i 's/mod_num_pages = .*;/mod_num_pages = 2;/g' $CP_INIT_CFG
         sed -i 's/allow_change_mac_address = false;/allow_change_mac_address = true;/g' $CP_INIT_CFG
         sed -i 's/acc_apf = 4;/acc_apf = 16;/g' $CP_INIT_CFG

--- a/docs/apps/lnw/es2k/es2k-lnw-overlay-vms.md
+++ b/docs/apps/lnw/es2k/es2k-lnw-overlay-vms.md
@@ -38,7 +38,7 @@ Modify `load_custom_pkg.sh` with following parameters for linux_networking packa
 
      ```bash
         sed -i 's/sem_num_pages = .*;/sem_num_pages = 28;/g' $CP_INIT_CFG
-        sed -i 's/lem_num_pages = .*;/lem_num_pages = 10;/g' $CP_INIT_CFG
+        sed -i 's/lem_num_pages = .*;/lem_num_pages = 32;/g' $CP_INIT_CFG
         sed -i 's/mod_num_pages = .*;/mod_num_pages = 2;/g' $CP_INIT_CFG
         sed -i 's/acc_apf = 4;/acc_apf = 16;/g' $CP_INIT_CFG
      ```

--- a/docs/apps/lnw/es2k/es2k-lnw-underlay-ecmp.md
+++ b/docs/apps/lnw/es2k/es2k-lnw-underlay-ecmp.md
@@ -39,7 +39,7 @@ Modify `load_custom_pkg.sh` with following parameters for linux_networking packa
 
      ```bash
         sed -i 's/sem_num_pages = .*;/sem_num_pages = 28;/g' $CP_INIT_CFG
-        sed -i 's/lem_num_pages = .*;/lem_num_pages = 10;/g' $CP_INIT_CFG
+        sed -i 's/lem_num_pages = .*;/lem_num_pages = 32;/g' $CP_INIT_CFG
         sed -i 's/mod_num_pages = .*;/mod_num_pages = 2;/g' $CP_INIT_CFG
         sed -i 's/acc_apf = 4;/acc_apf = 16;/g' $CP_INIT_CFG
      ```

--- a/docs/apps/lnw/es2k/es2k-lnw-underlay-frr.md
+++ b/docs/apps/lnw/es2k/es2k-lnw-underlay-frr.md
@@ -39,7 +39,7 @@ Modify `load_custom_pkg.sh` with following parameters for linux_networking packa
 
      ```bash
         sed -i 's/sem_num_pages = .*;/sem_num_pages = 28;/g' $CP_INIT_CFG
-        sed -i 's/lem_num_pages = .*;/lem_num_pages = 10;/g' $CP_INIT_CFG
+        sed -i 's/lem_num_pages = .*;/lem_num_pages = 32;/g' $CP_INIT_CFG
         sed -i 's/mod_num_pages = .*;/mod_num_pages = 2;/g' $CP_INIT_CFG
         sed -i 's/acc_apf = 4;/acc_apf = 16;/g' $CP_INIT_CFG
      ```

--- a/docs/apps/lnw/es2k/es2k-lnw-underlay-lag.md
+++ b/docs/apps/lnw/es2k/es2k-lnw-underlay-lag.md
@@ -39,7 +39,7 @@ Modify `load_custom_pkg.sh` with following parameters for linux_networking packa
 
      ```bash
         sed -i 's/sem_num_pages = .*;/sem_num_pages = 28;/g' $CP_INIT_CFG
-        sed -i 's/lem_num_pages = .*;/lem_num_pages = 10;/g' $CP_INIT_CFG
+        sed -i 's/lem_num_pages = .*;/lem_num_pages = 32;/g' $CP_INIT_CFG
         sed -i 's/mod_num_pages = .*;/mod_num_pages = 2;/g' $CP_INIT_CFG
         sed -i 's/allow_change_mac_address = false;/allow_change_mac_address = true;/g' $CP_INIT_CFG
         sed -i 's/acc_apf = 4;/acc_apf = 16;/g' $CP_INIT_CFG


### PR DESCRIPTION
Have noticed that some usecases see failures in p4 tables written to hw. Recommending users increase the number of lem_num_pages to 32 now