### PR TITLE
Update LNW + IPsec documentation for 1.8

### DIFF
--- a/docs/apps/ipsec-offload.md
+++ b/docs/apps/ipsec-offload.md
@@ -48,7 +48,7 @@ to load the hardware FXP pipeline with the IPsec package.
 Follow the instructions in
 [Running infrap4d](/guides/es2k/running-infrap4d.md)
 and prepare the system with generated TDI.json and context.json file references.
-In order to  offload IPsec, fixed function support must be enabled in infrap4d. 
+In order to  offload IPsec, fixed function support must be enabled in infrap4d.
 
 The /usr/share/stratum/es2k/es2k_skip_p4.conf file must include the fixed
 function configuration reference.
@@ -78,4 +78,3 @@ With the strongSwan application configured, starting IPsec
 initiate the pipeline, program the SPD rules as per the P4 program, and
 configure/re-configure SAD entries based on negotiated encryption parameters
 between local and peer system.
-

--- a/docs/apps/ipsec-offload.md
+++ b/docs/apps/ipsec-offload.md
@@ -30,6 +30,7 @@ YANG model is used to configure IPsec offload.
 ## Enabling IPsec
 
 Follow the sequence of steps listed below to enable IPsec functionality.
+The `fxp-net_linux-networking` P4 program is a combined recipe which implements and supports both the Linux Networking and the IPsec portion of the program.
 
 ### Compile P4 program
 
@@ -37,7 +38,7 @@ Compile the ipsec-offload program according to the instructions in
 [Compiling P4 programs](/guides/es2k/compiling-p4-programs.md)
 to generate crypto P4 artifacts for programming the pipelines.
 
-### Load IPsec P4 package
+### Load `fxp-net_linux-networking` P4 package
 
 Follow the instructions in [Deploying P4 programs](/guides/es2k/deploying-p4-programs.md)
 to load the hardware FXP pipeline with the IPsec package.
@@ -78,62 +79,3 @@ initiate the pipeline, program the SPD rules as per the P4 program, and
 configure/re-configure SAD entries based on negotiated encryption parameters
 between local and peer system.
 
-## OpenConfig and gNMI messages
-
-This section provides detailed information on OpenConfig model and gNMI
-messages with the expected format. The strongSwan plugin has the following
-details encoded, and user interaction is not needed.
-
-### Config SAD message
-
-The P4 Control Plane provides SET and DELETE service to the
-IPsec-offload [Config SAD message](https://github.com/ipdk-io/openconfig-public/blob/master/release/models/ipsec/openconfig-ipsec-offload.yang#L39-L185)
-at `/ipsec-offload/sad/sad-entry[offload-id=x][direction=y]/config`.
-
-Note that individual leaf nodes of the YANG tree cannot be set and the gRPC
-server expects the full config message as one single message. This design
-was chosen in order to avoid caching of the encryption keys in the
-software stack.
-
-The expected format of the Config SAD message is:
-
-```text
-offload_id: 1,
-direction: true,
-req_id: 2,
-spi: 599,
-ext_seq_num: false,
-anti_replay_window_size: 64,
-protocol_parameters: IPSEC_PROTOCOL_PARAMS_ESP,
-mode: IPSEC_MODE_TRANSPORT,
-esp_payload {
-  encryption {
-    encryption_algorithm: 12,
-    key: "33:65:6b:12:d7:9f:56:63:0b:59:a3:9f:8b:03:d2:c1:b8:51:98:e8",
-    key_len: 20,
-  }
-},
-sa_hard_lifetime {
-  bytes: 200000
-},
-sa_soft_lifetime {
-  bytes: 100000
-}
-```
-
-### Fetch SPI message
-
-The GET gNMI call is used to retrieve the
-[SPI value](https://github.com/ipdk-io/openconfig-public/blob/master/release/models/ipsec/openconfig-ipsec-offload.yang#L292)
-at `/ipsec-offload/ipsec-spi/rx-spi`.
-
-### Key Expiry Notification message
-
-The [gRPC Notification message](https://github.com/ipdk-io/openconfig-public/blob/master/release/models/ipsec/openconfig-ipsec-offload.yang#L308)
-at `/ipsec-offload/sadb-expire` is used as a signal to trigger the
-re-keying mechanism in IKE protocol.
-
-A gNMI subscription stream is opened from the gNMI client listening to these
-notification messages originating in the target. Upon receiving this
-notification, client will initiate the re-keying mechanism to refresh
-the encryption keys.

--- a/docs/apps/lnw/es2k/es2k-lnw-overlay-ipv6.md
+++ b/docs/apps/lnw/es2k/es2k-lnw-overlay-ipv6.md
@@ -41,7 +41,8 @@ Modify `load_custom_pkg.sh` with following parameters for linux_networking packa
         sed -i 's/sem_num_pages = .*;/sem_num_pages = 28;/g' $CP_INIT_CFG
         sed -i 's/lem_num_pages = .*;/lem_num_pages = 32;/g' $CP_INIT_CFG
         sed -i 's/mod_num_pages = .*;/mod_num_pages = 2;/g' $CP_INIT_CFG
-        sed -i 's/allow_change_mac_address = false;/allow_change_mac_address = true;/g' $CP_INIT_CFG
+        sed -i 's/cxp_num_pages = .*;/cxp_num_pages = 5;/g' $CP_INIT_CFG # for IPsec use-case
+        sed -i 's/allow_change_mac_address = false;/allow_change_mac_address = true;/g' $CP_INIT_CFG # for LAG use-case
         sed -i 's/acc_apf = 4;/acc_apf = 16;/g' $CP_INIT_CFG
      ```
 

--- a/docs/apps/lnw/es2k/es2k-lnw-overlay-vms.md
+++ b/docs/apps/lnw/es2k/es2k-lnw-overlay-vms.md
@@ -40,6 +40,8 @@ Modify `load_custom_pkg.sh` with following parameters for linux_networking packa
         sed -i 's/sem_num_pages = .*;/sem_num_pages = 28;/g' $CP_INIT_CFG
         sed -i 's/lem_num_pages = .*;/lem_num_pages = 32;/g' $CP_INIT_CFG
         sed -i 's/mod_num_pages = .*;/mod_num_pages = 2;/g' $CP_INIT_CFG
+        sed -i 's/cxp_num_pages = .*;/cxp_num_pages = 5;/g' $CP_INIT_CFG # for IPsec use-case
+        sed -i 's/allow_change_mac_address = false;/allow_change_mac_address = true;/g' $CP_INIT_CFG # for LAG use-case
         sed -i 's/acc_apf = 4;/acc_apf = 16;/g' $CP_INIT_CFG
      ```
 

--- a/docs/apps/lnw/es2k/es2k-lnw-underlay-ecmp.md
+++ b/docs/apps/lnw/es2k/es2k-lnw-underlay-ecmp.md
@@ -41,6 +41,8 @@ Modify `load_custom_pkg.sh` with following parameters for linux_networking packa
         sed -i 's/sem_num_pages = .*;/sem_num_pages = 28;/g' $CP_INIT_CFG
         sed -i 's/lem_num_pages = .*;/lem_num_pages = 32;/g' $CP_INIT_CFG
         sed -i 's/mod_num_pages = .*;/mod_num_pages = 2;/g' $CP_INIT_CFG
+        sed -i 's/cxp_num_pages = .*;/cxp_num_pages = 5;/g' $CP_INIT_CFG # for IPsec use-case
+        sed -i 's/allow_change_mac_address = false;/allow_change_mac_address = true;/g' $CP_INIT_CFG # for LAG use-case
         sed -i 's/acc_apf = 4;/acc_apf = 16;/g' $CP_INIT_CFG
      ```
 

--- a/docs/apps/lnw/es2k/es2k-lnw-underlay-frr.md
+++ b/docs/apps/lnw/es2k/es2k-lnw-underlay-frr.md
@@ -41,6 +41,8 @@ Modify `load_custom_pkg.sh` with following parameters for linux_networking packa
         sed -i 's/sem_num_pages = .*;/sem_num_pages = 28;/g' $CP_INIT_CFG
         sed -i 's/lem_num_pages = .*;/lem_num_pages = 32;/g' $CP_INIT_CFG
         sed -i 's/mod_num_pages = .*;/mod_num_pages = 2;/g' $CP_INIT_CFG
+        sed -i 's/cxp_num_pages = .*;/cxp_num_pages = 5;/g' $CP_INIT_CFG # for IPsec use-case
+        sed -i 's/allow_change_mac_address = false;/allow_change_mac_address = true;/g' $CP_INIT_CFG # for LAG use-case
         sed -i 's/acc_apf = 4;/acc_apf = 16;/g' $CP_INIT_CFG
      ```
 

--- a/docs/apps/lnw/es2k/es2k-lnw-underlay-lag.md
+++ b/docs/apps/lnw/es2k/es2k-lnw-underlay-lag.md
@@ -41,7 +41,9 @@ Modify `load_custom_pkg.sh` with following parameters for linux_networking packa
         sed -i 's/sem_num_pages = .*;/sem_num_pages = 28;/g' $CP_INIT_CFG
         sed -i 's/lem_num_pages = .*;/lem_num_pages = 32;/g' $CP_INIT_CFG
         sed -i 's/mod_num_pages = .*;/mod_num_pages = 2;/g' $CP_INIT_CFG
-        sed -i 's/allow_change_mac_address = false;/allow_change_mac_address = true;/g' $CP_INIT_CFG
+        sed -i 's/cxp_num_pages = .*;/cxp_num_pages = 5;/g' $CP_INIT_CFG # for IPsec use-case
+        sed -i 's/allow_change_mac_address = false;/allow_change_mac_address = true;/g' $CP_INIT_CFG # for LAG use-case
+
         sed -i 's/acc_apf = 4;/acc_apf = 16;/g' $CP_INIT_CFG
      ```
 
@@ -359,11 +361,21 @@ The following configuration assumes that:
 #     ip link add bond0 type bond miimon 100 mode active-backup
 # For dynamic LAG:
 #     ip link add bond0 type bond miimon 100 mode 802.3ad
+
+# Note: Some Linux environments have experienced issues in LAG/LACP configuring and rule programming.
+# Adding a 5s delay between each command resolves this timing issue.
+
 ip link set <IDPF netdev for VSI 10> down
+sleep 5
 ip link set <IDPF netdev for VSI 10> master bond0
+sleep 5
 ip link set <IDPF netdev for VSI 11> down
+sleep 5
 ip link set <IDPF netdev for VSI 11> master bond0
+sleep 5
 ip link set bond0 up
+
+# Assign IP address to bonf interface and add route to reach remote IP
 ifconfig bond0 40.1.1.1/24 up
 ip route change 40.1.1.0/24 via 40.1.1.2 dev bond0
 ```

--- a/docs/apps/lnw/es2k/es2k-lnw-underlay-lag.md
+++ b/docs/apps/lnw/es2k/es2k-lnw-underlay-lag.md
@@ -363,7 +363,7 @@ The following configuration assumes that:
 #     ip link add bond0 type bond miimon 100 mode 802.3ad
 
 # Note: Some Linux environments have experienced issues in LAG/LACP configuring and rule programming.
-# Adding a 5s delay between each command resolves this timing issue.
+# Adding a 5s delay between commands resolves this timing issue.
 
 ip link set <IDPF netdev for VSI 10> down
 sleep 5
@@ -375,7 +375,7 @@ ip link set <IDPF netdev for VSI 11> master bond0
 sleep 5
 ip link set bond0 up
 
-# Assign IP address to bonf interface and add route to reach remote IP
+# Assign IP address to bond interface and add route to reach remote IP
 ifconfig bond0 40.1.1.1/24 up
 ip route change 40.1.1.0/24 via 40.1.1.2 dev bond0
 ```


### PR DESCRIPTION
Changes in this PR

* Updated all load_custom_config.sh to make it generic, with a comment to indicate two fields are for LAG and IPsec usecase
* Update the IPsec doc to point that we now use the LNW combined recipe
* Remove the second half of the IPsec doc which simply gives some design details -- something that the user does not have to handle manually. All this is done by the ipsec strongSwan plugin code
* LAG/LACP has seen some issues when bulk programming rules -- adding a delay avoids this problem. Added a note in documentation to point this out