### PR TITLE
Update table names and couple of other typos

### DIFF
--- a/docs/apps/lnw/es2k/es2k-linux-networking.md
+++ b/docs/apps/lnw/es2k/es2k-linux-networking.md
@@ -36,18 +36,18 @@ This topology breakdown and configuration assumes all VMs are spawned on HOST VF
 
 To enable slow path mode:
 
-- Start the infrap4d process with the Kernel Monitor disabled. Command: `infrap4d -disable-krnlmon`
+- Start the infrap4d process with the Kernel Monitor disabled. Command: `infrap4d -disable_krnlmon`
 - Set environment variable `OVS_P4_OFFLOAD=false` before starting the `ovs-vswitchd` process.
 
 In this mode, VMs are spawned on top of VFs and associated with their port representors. Also, physical ports are associated with their port representors. Configure the following tables to map these in IPU:
 
 ```text
 - rx_source_port
-- tx_source_port_v4/tx_source_port_v6
+- rx_phy_port_to_pr_map
+- tx_source_port
 - tx_acc_vsi
 - vsi_to_vsi_loopback
 - source_port_to_pr_map
-- rx_phy_port_to_pr_map
 ```
 
 All port representors (PRs) in ACC should be associated with an OvS bridge. Configure table below to program the mapping between PRs and bridges in IPU:
@@ -154,11 +154,11 @@ Configure tables:
 
 ```text
 - rx_source_port
-- tx_source_port_v4/tx_source_port_v6
+- rx_phy_port_to_pr_map
+- tx_source_port
 - tx_acc_vsi
 - vsi_to_vsi_loopback
 - source_port_to_pr_map
-- rx_phy_port_to_pr_map
 - tx_lag_table     ## This is a dummy LAG entry when we have underlay as Non LAG case.
 ```
 

--- a/docs/apps/lnw/es2k/es2k-lnw-overlay-ipv6.md
+++ b/docs/apps/lnw/es2k/es2k-lnw-overlay-ipv6.md
@@ -215,7 +215,7 @@ Example:
 ```bash
 # Create a source port for an overlay VF (VSI-27). Source port action can be any value.
 # For simplicity add 16 to VSI ID.
- p4rt-ctl add-entry br0 linux_networking_control.tx_source_port_v6 \
+ p4rt-ctl add-entry br0 linux_networking_control.tx_source_port \
      "vmeta.common.vsi=27,zero_padding=0,action=linux_networking_control.set_source_port(43)"
 
 # Create a mapping between overlay VF (VSI-27/source port-43) and ACC port representor (VSI-9)
@@ -276,7 +276,7 @@ Example:
 ```bash
 # Create a source port for an overlay VF (VSI-24). Source port action can be any value.
 # For simplicity add 16 to VSI ID.
- p4rt-ctl add-entry br0 linux_networking_control.tx_source_port_v6 \
+ p4rt-ctl add-entry br0 linux_networking_control.tx_source_port \
      "vmeta.common.vsi=24,zero_padding=0,action=linux_networking_control.set_source_port(40)"
 
 # Create a mapping between overlay VF (VSI-24/source port-40) and ACC port representor (VSI-18)

--- a/docs/apps/lnw/es2k/es2k-lnw-overlay-vms.md
+++ b/docs/apps/lnw/es2k/es2k-lnw-overlay-vms.md
@@ -221,7 +221,7 @@ Example:
 
   ```bash
      # Create a source port for an overlay VF (VSI-27). Source port value should be VSI ID + 16.
-      p4rt-ctl add-entry br0 linux_networking_control.tx_source_port_v4 \
+      p4rt-ctl add-entry br0 linux_networking_control.tx_source_port \
       "vmeta.common.vsi=27/2047,priority=1,action=linux_networking_control.set_source_port(43)"
    ```
 
@@ -287,7 +287,7 @@ Example:
 
   ```bash
      # Create a source port for an APF netdev (VSI-24). Source port value should be VSI ID + 16.
-      p4rt-ctl add-entry br0 linux_networking_control.tx_source_port_v4 \
+      p4rt-ctl add-entry br0 linux_networking_control.tx_source_port \
       "vmeta.common.vsi=24/2047,priority=1,action=linux_networking_control.set_source_port(40)"
    ```
 

--- a/docs/apps/lnw/es2k/es2k-lnw-underlay-ecmp.md
+++ b/docs/apps/lnw/es2k/es2k-lnw-underlay-ecmp.md
@@ -217,7 +217,7 @@ Example:
 
   ```bash
      # Create a source port for an overlay VF (VSI-27). Source port value should be VSI ID + 16.
-      p4rt-ctl add-entry br0 linux_networking_control.tx_source_port_v4 \
+      p4rt-ctl add-entry br0 linux_networking_control.tx_source_port \
       "vmeta.common.vsi=27/2047,priority=1,action=linux_networking_control.set_source_port(43)"
    ```
 
@@ -284,7 +284,7 @@ Example:
 
   ```bash
      # Create a source port for an APF netdev (VSI-24). Source port value should be VSI ID + 16.
-      p4rt-ctl add-entry br0 linux_networking_control.tx_source_port_v4 \
+      p4rt-ctl add-entry br0 linux_networking_control.tx_source_port \
       "vmeta.common.vsi=24/2047,priority=1,action=linux_networking_control.set_source_port(40)"
    ```
 

--- a/docs/apps/lnw/es2k/es2k-lnw-underlay-frr.md
+++ b/docs/apps/lnw/es2k/es2k-lnw-underlay-frr.md
@@ -214,7 +214,7 @@ Example:
 
   ```bash
      # Create a source port for an overlay VF (VSI-27). Source port value should be VSI ID + 16.
-      p4rt-ctl add-entry br0 linux_networking_control.tx_source_port_v4 \
+      p4rt-ctl add-entry br0 linux_networking_control.tx_source_port \
       "vmeta.common.vsi=27/2047,priority=1,action=linux_networking_control.set_source_port(43)"
    ```
 
@@ -279,7 +279,7 @@ Example:
 
   ```bash
      # Create a source port for an APF netdev (VSI-24). Source port value should be VSI ID + 16.
-      p4rt-ctl add-entry br0 linux_networking_control.tx_source_port_v4 \
+      p4rt-ctl add-entry br0 linux_networking_control.tx_source_port \
       "vmeta.common.vsi=24/2047,priority=1,action=linux_networking_control.set_source_port(40)"
    ```
 

--- a/docs/apps/lnw/es2k/es2k-lnw-underlay-lag.md
+++ b/docs/apps/lnw/es2k/es2k-lnw-underlay-lag.md
@@ -219,7 +219,7 @@ Example:
 
   ```bash
      # Create a source port for an overlay VF (VSI-27). Source port value should be VSI ID + 16.
-      p4rt-ctl add-entry br0 linux_networking_control.tx_source_port_v4 \
+      p4rt-ctl add-entry br0 linux_networking_control.tx_source_port \
       "vmeta.common.vsi=27/2047,priority=1,action=linux_networking_control.set_source_port(43)"
    ```
 
@@ -284,7 +284,7 @@ Example:
 
   ```bash
      # Create a source port for an APF netdev (VSI-24). Source port value should be VSI ID + 16.
-      p4rt-ctl add-entry br0 linux_networking_control.tx_source_port_v4 \
+      p4rt-ctl add-entry br0 linux_networking_control.tx_source_port \
       "vmeta.common.vsi=24/2047,priority=1,action=linux_networking_control.set_source_port(40)"
    ```
 


### PR DESCRIPTION
* Updated all references to use correct table (`tx_source_port_v4` and `tx_source_port_v6` were consolidated into `tx_source_port`)
* Correct the typo for `-disable_krnlmon` (the flag uses underscore and not hyphen)
