### PR TITLE
Fix documentation error with tx_acc_vsi table

### DIFF
--- a/docs/apps/lnw/es2k/es2k-lnw-overlay-vms.md
+++ b/docs/apps/lnw/es2k/es2k-lnw-overlay-vms.md
@@ -1,6 +1,6 @@
 <!--
 
- Copyright 2024 Intel Corporation.
+ Copyright 2024,2025 Intel Corporation.
 
  SPDX-License-Identifier: Apache-2.0
 
@@ -299,7 +299,7 @@ Example:
      "user_meta.cmeta.source_port=40,zero_padding=0,action=linux_networking_control.fwd_to_vsi(34)"
 
  p4rt-ctl add-entry br0 linux_networking_control.tx_acc_vsi \
-     "vmeta.common.vsi=17,zero_padding=0,action=linux_networking_control.l2_fwd_and_bypass_bridge(0)"
+     "vmeta.common.vsi=18,zero_padding=0,action=linux_networking_control.l2_fwd_and_bypass_bridge(40)"
 
 # Create a mapping for traffic to flow between VSIs (VSI-24/source port-40) and (VSI-18)
  p4rt-ctl add-entry br0 linux_networking_control.vsi_to_vsi_loopback \


### PR DESCRIPTION
This PR modifies correct p4 runtime rule for communication between Port Representor on ACC to APF netdev on ACC.